### PR TITLE
Fix: use injected URLSession instead of .shared

### DIFF
--- a/Sources/ADNetwork/ADNetwork.swift
+++ b/Sources/ADNetwork/ADNetwork.swift
@@ -11,7 +11,7 @@ final public class ADNetwork: Sendable {
     }
 
     public func data(for request: URLRequest) async throws -> Data {
-        let (data, _) = try await URLSession.shared.data(for: request)
+        let (data, _) = try await urlSession.data(for: request)
         return data
     }
 


### PR DESCRIPTION
## Summary
- `ADNetwork.data(for:)` ignored the `URLSession` passed via `init` and always used `URLSession.shared`
- Now correctly uses the injected `urlSession` instance, restoring dependency injection

## Test plan
- [ ] Verify requests go through the custom `URLSession` when one is provided
- [ ] Verify default behavior still works when no session is passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)